### PR TITLE
Do not send analysis information when page loading on locahost.

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -155,14 +155,18 @@
     var _gaId = '{{ site.ga_track_id }}';
     var _gaDomain = '{{ site.ga_domain }}';
 
-    // Originial
-    (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
-    (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
-    m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
-    })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
+    // check whether running on localhost
+    var re = new RegExp('^(127.0.0.1|localhost)$')
+    if (!re.test(document.location.hostname)) {
+        // Originial
+        (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
+        (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
+        m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)
+        })(window,document,'script','//www.google-analytics.com/analytics.js','ga');
 
-    ga('create', _gaId, _gaDomain);
-    ga('send', 'pageview');
+        ga('create', _gaId, _gaDomain);
+        ga('send', 'pageview');
+    }
 </script>
 {% endif %}
 
@@ -173,13 +177,17 @@
     // dynamic User by Hux
     var _baId = '{{ site.ba_track_id }}';
 
-    // Originial
-    var _hmt = _hmt || [];
-    (function() {
-      var hm = document.createElement("script");
-      hm.src = "//hm.baidu.com/hm.js?" + _baId;
-      var s = document.getElementsByTagName("script")[0];
-      s.parentNode.insertBefore(hm, s);
-    })();
+    // check whether running on localhost
+    var re = new RegExp('^(127.0.0.1|localhost)$')
+    if (!re.test(document.location.hostname)) {
+        // Originial
+        var _hmt = _hmt || [];
+        (function() {
+          var hm = document.createElement("script");
+          hm.src = "//hm.baidu.com/hm.js?" + _baId;
+          var s = document.getElementsByTagName("script")[0];
+          s.parentNode.insertBefore(hm, s);
+        })();
+    }
 </script>
 {% endif %}


### PR DESCRIPTION
We can use `jekyll serve` command to setup a local server for debugging. For pages visiting from localhost, we don't need to send analysis info(Baidu or Google).
